### PR TITLE
ci: use sticky super-linter comment and drop pinact config

### DIFF
--- a/.github/workflows/_linter.yml
+++ b/.github/workflows/_linter.yml
@@ -36,3 +36,13 @@ jobs:
         uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
+          SAVE_SUPER_LINTER_SUMMARY: true
+          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: false
+
+      - name: Update sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
+        with:
+          header: super-linter-report
+          path: ${{ github.workspace }}/super-linter-output/super-linter-summary.md

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,9 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
-# pinact - https://github.com/suzuki-shunsuke/pinact
-files:
-  - pattern: "^\\.github/workflows/.*\\.ya?ml$"
-  - pattern: "^(.*/)?action\\.ya?ml$"
-
-ignore_actions:
-# - name: actions/checkout
-# - name: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml


### PR DESCRIPTION
## Summary
- disable Super-Linter's built-in PR summary comment and save markdown summary output
- post/update a single sticky PR comment from the generated summary
- remove optional .pinact.yaml (default pinact targets are sufficient)

## Notes
- sticky-pull-request-comment is pinned to a full commit SHA via pinact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter workflow configuration to display pull request linting reports as persistent comments for improved visibility during code review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->