### PR TITLE
chore(renovate): fix ignored author and source-specific minimumReleaseAge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
   assigneesFromCodeOwners: true,
   packageRules: [
     {
+      matchSourceUrls: [
+        'https://github.com/air-hand-org/**',
+        'https://github.com/actions/**',
+      ],
+      minimumReleaseAge: '0 days',
+    },
+    {
       matchUpdateTypes: ['major'],
       addLabels: ['major']
     },
@@ -32,7 +39,7 @@
   },
   // Ignore CI commits from the release app so Renovate keeps rebasing/updating its PR branches.
   gitIgnoredAuthors: [
-    'air-hand-release-app[bot] <276784480+air-hand-release-app[bot]@users.noreply.github.com>',
+    '276784480+air-hand-release-app[bot]@users.noreply.github.com',
   ],
   rebaseWhen: "behind-base-branch",
   minimumReleaseAge: "3 days",


### PR DESCRIPTION
Summary:\n- fix gitIgnoredAuthors to use email form for release app bot\n- set minimumReleaseAge to 0 days for air-hand-org/* and actions/*\n- keep global minimumReleaseAge at 3 days for other sources\n\nContext:\n- Renovate posted edited/blocked notification on PRs with release-app commits\n- trusted sources should not be delayed by minimum release age