### PR TITLE
refactor(ci): add PR title lint for squash merge workflow

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -11,6 +11,33 @@ on:
 permissions: {}
 
 jobs:
+  pr-title:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: PR Title Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Lint PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+
   test:
     uses: ./.github/workflows/_test.yml
     permissions:

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Lint PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- add PR title lint job in reusable CI workflow
- enforce Conventional Commit style for pull request titles
- run only on pull_request events so push workflows are unaffected

## Note
- action ref is currently v5; we can pin with pinact afterward