### PR TITLE
build(dist): retitle bot PRs when check-dist updates generated files

### DIFF
--- a/.github/workflows/_check-dist.yml
+++ b/.github/workflows/_check-dist.yml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Create GitHub App Token
@@ -37,6 +38,7 @@ jobs:
           client-id: ${{ inputs.gh_app_release_client_id }}
           private-key: ${{ secrets.GH_APP_RELEASE_PRIVATE_KEY }}
           permission-contents: write
+          permission-pull-requests: write
 
       - name: get app information
         id: app-info
@@ -88,8 +90,31 @@ jobs:
           git config user.email "${GIT_USER_EMAIL}"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add -A
-          git commit -m "chore(ci): sync generated files"
+          git commit -m "build(dist): sync generated files"
           git push origin "HEAD:${BRANCH}"
+
+      - name: Retitle Bot PR to build(dist)
+        if: ${{ steps.diff.outputs.has_changes == 'true' && github.event_name == 'pull_request' && github.event.pull_request.user.type == 'Bot' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          current_title="$(jq -r '.pull_request.title' "${GITHUB_EVENT_PATH}")"
+
+          if ! printf '%s' "${current_title}" | grep -Eq '^[a-z]+(\([^)]*\))?(!)?:[[:space:]]+'; then
+            exit 0
+          fi
+
+          new_title="$(printf '%s' "${current_title}" | sed -E 's/^[a-z]+(\([^)]*\))?(!)?:[[:space:]]+/build(dist): /')"
+
+          if [ "${current_title}" = "${new_title}" ]; then
+            exit 0
+          fi
+
+          gh api \
+            --method PATCH \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            -f "title=${new_title}"
 
       # This will fail the workflow if generated files are different than
       # expected.

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -11,6 +11,33 @@ on:
 permissions: {}
 
 jobs:
+  pr-title:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: PR Title Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Lint PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+
   test:
     uses: ./.github/workflows/_test.yml
     permissions:

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Lint PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- change check-dist auto-commit message to build(dist): sync generated files
- when check-dist detects changes on a bot-authored PR, rewrite only the PR title prefix to build(dist)
- keep the rest of the PR title text intact
- grant pull-requests: write to the check-dist job/app token for title updates